### PR TITLE
Fixed so classes with Guids datatype can be faked.

### DIFF
--- a/FakeO.Tests/FakeDataTest.cs
+++ b/FakeO.Tests/FakeDataTest.cs
@@ -91,5 +91,13 @@ namespace FakeO.Tests
           Assert.AreNotEqual(0, obj.Decimal);
           Assert.AreNotEqual(0, obj.Double);
       }
+
+      [TestMethod]
+      public void Fake_CanHandleGuids()
+      {
+          var guidObject = Create.Fake<TestClassWithAGuid>();
+
+          Assert.AreNotEqual(Guid.Empty, guidObject.UniqueId);
+      }
   }
 }

--- a/FakeO.Tests/TestClasses.cs
+++ b/FakeO.Tests/TestClasses.cs
@@ -54,6 +54,13 @@ namespace FakeO.Tests
     public TimeSpan ManuallySetTime;
   }
 
+    public class TestClassWithAGuid
+    {
+        public string Property1 { get; set; }
+        public string Property2 { get; set; }
+        public Guid UniqueId { get; set; }
+    }
+
   public class NestedTestClass
   {
     public PublicTestClass Nested { get; set; }

--- a/FakeO/Data.cs
+++ b/FakeO/Data.cs
@@ -43,6 +43,8 @@ namespace FakeO
         return RandomDecimal(min, max);
       if (t == typeof(char) || t == typeof(char?))
         return String.Random(1)[0];
+      if (t == typeof(Guid) || t == typeof(Guid?)) 
+        return Guid.NewGuid();       // By defination Guids are to be unique
       if (t == typeof(string))
         return RandomString(min, max);
       if (t == typeof(DateTime) || t == typeof(DateTime?))


### PR DESCRIPTION
I was using FakeO in my project and I added a unique Id as a GUID and got the follow error.

System.TypeInitializationException : The type initializer for 'MyNamespace.FooTestData' threw an exception.
  ----> System.ArgumentException : Object of type 'System.Int32' cannot be converted to type 'System.Guid'.

The issue is now fixed, with both a test and the change.
